### PR TITLE
Add -NoOuterPipes/-PadSpaces options and Pester tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,16 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester
+          $Result = Invoke-Pester -Path ./tests -PassThru
+          if ($Result.FailedCount -gt 0) {
+              throw "$($Result.FailedCount) test(s) failed"
+          }
+
       # https://github.com/marketplace/actions/publish-powershell-module
       - name: Publish Module to PowerShell Gallery
         uses: pcgeek86/publish-powershell-module-action@v20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  # Pushes to main are covered by deploy.yml, which runs the same tests as a
+  # gate before publishing. This workflow covers everything deploy.yml
+  # doesn't: PRs, and pushes to other branches.
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+jobs:
+  pester:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester
+          $Result = Invoke-Pester -Path ./tests -PassThru
+          if ($Result.FailedCount -gt 0) {
+              throw "$($Result.FailedCount) test(s) failed"
+          }

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Most of the credit goes to:
 
 `gci | select Name,FullName | fmd`
 ```text
-Name      | FullName
---------- | -------------------------------------------------------------
-src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src
-LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE
-README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md
+| Name      | FullName                                                      |
+| --------- | ------------------------------------------------------------- |
+| src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src       |
+| LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE   |
+| README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md |
 ```
 
 ### Longhand Examples
@@ -31,11 +31,41 @@ README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md
 Get-ChildItem | Select-Object Name,FullName | Format-Markdown
 ```
 ```text
-Name      | FullName
+| Name      | FullName                                                      |
+| --------- | ------------------------------------------------------------- |
+| src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src       |
+| LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE   |
+| README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md |
+```
+
+By default, each row is wrapped in a leading and trailing pipe, per the
+[GFM table spec's recommended style](https://github.github.com/gfm/#tables-extension-),
+padded with a space on each side of every pipe - inner separators and outer
+wrapping alike. Two switches control that:
+
+* `-NoOuterPipes` - drop the leading/trailing pipe for the leaner style some renderers produce.
+* `-PadSpaces <n>` - change the padding width (default `1`); `0` packs every pipe tight against its neighboring cell.
+
+```powershell
+Get-ChildItem | Select-Object Name,FullName | Format-Markdown -NoOuterPipes
+```
+```text
+Name      | FullName                                                     
 --------- | -------------------------------------------------------------
-src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src
-LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE
+src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src      
+LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE  
 README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md
+```
+
+```powershell
+Get-ChildItem | Select-Object Name,FullName | Format-Markdown -PadSpaces 0
+```
+```text
+|Name     |FullName                                                     |
+|---------|-------------------------------------------------------------|
+|src      |/Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src      |
+|LICENSE  |/Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE  |
+|README.md|/Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md|
 ```
 
 #### JSON Table

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,11 +17,11 @@ gci | select Name,FullName | fmd
 ```
 
 ```text
-Name      | FullName
---------- | -------------------------------------------------------------
-src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src
-LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE
-README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md
+| Name      | FullName                                                      |
+| --------- | ------------------------------------------------------------- |
+| src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src       |
+| LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE   |
+| README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md |
 ```
 
 ### Markdown Table
@@ -31,11 +31,43 @@ Get-ChildItem | Select-Object Name,FullName | Format-Markdown
 ```
 
 ```text
-Name      | FullName
+| Name      | FullName                                                      |
+| --------- | ------------------------------------------------------------- |
+| src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src       |
+| LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE   |
+| README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md |
+```
+
+By default, each row is wrapped in a leading and trailing pipe, per the
+[GFM table spec's recommended style](https://github.github.com/gfm/#tables-extension-),
+padded with a space on each side of every pipe - inner separators and outer
+wrapping alike. Two switches control that:
+
+* `-NoOuterPipes` - drop the leading/trailing pipe for the leaner style some renderers produce.
+* `-PadSpaces <n>` - change the padding width (default `1`); `0` packs every pipe tight against its neighboring cell.
+
+```powershell
+Get-ChildItem | Select-Object Name,FullName | Format-Markdown -NoOuterPipes
+```
+
+```text
+Name      | FullName                                                     
 --------- | -------------------------------------------------------------
-src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src
-LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE
+src       | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src      
+LICENSE   | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE  
 README.md | /Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md
+```
+
+```powershell
+Get-ChildItem | Select-Object Name,FullName | Format-Markdown -PadSpaces 0
+```
+
+```text
+|Name     |FullName                                                     |
+|---------|-------------------------------------------------------------|
+|src      |/Users/cpeterson/src/github/chris-peterson/pwsh-fmd/src      |
+|LICENSE  |/Users/cpeterson/src/github/chris-peterson/pwsh-fmd/LICENSE  |
+|README.md|/Users/cpeterson/src/github/chris-peterson/pwsh-fmd/README.md|
 ```
 
 ### JSON Table

--- a/src/Format-Markdown/Format-Markdown.psm1
+++ b/src/Format-Markdown/Format-Markdown.psm1
@@ -57,20 +57,20 @@ function Format-Markdown{
             foreach ($Key in $Columns.Keys) {
                 $HeaderRow += ('{0,-' + $Columns[$Key] + '}') -f $Key
             }
-            $Output += "$($HeaderRow -join ' | ')`n"
+            $Output += "|$($HeaderRow -join ' | ')|`n"
 
             $SeparatorRow = @()
             foreach ($Key in $Columns.Keys) {
                 $SeparatorRow += '-' * $Columns[$Key]
             }
-            $Output += "$($SeparatorRow -join ' | ')`n"
+            $Output += "|$($SeparatorRow -join ' | ')|`n"
 
             foreach ($Item in $Items) {
                 $DataRow = @()
                 foreach($key in $Columns.Keys) {
                     $DataRow += ('{0,-' + $Columns[$key] + '}') -f $Item.($key)
                 }
-                $Output += "$($DataRow -join ' | ')`n"
+                $Output += "|$($DataRow -join ' | ')|`n"
             }
         }
         Write-Output $Output

--- a/src/Format-Markdown/Format-Markdown.psm1
+++ b/src/Format-Markdown/Format-Markdown.psm1
@@ -9,7 +9,24 @@ function Format-Markdown{
 
         [switch]
         [Parameter()]
-        $AsJsonTable
+        $AsJsonTable,
+
+        # GFM permits omitting the leading/trailing pipe on each table row, but
+        # recommends keeping it "for clarity of reading, and if there's
+        # otherwise parsing ambiguity" (https://github.github.com/gfm/#tables-extension-).
+        # Default to that recommended, canonical form; this switch opts back
+        # into the leaner style some renderers/tools produce.
+        [switch]
+        [Parameter()]
+        $NoOuterPipes,
+
+        # Spaces of padding on each side of every pipe - the inner column
+        # separators, and (when present) the outer wrapping pipes. Defaults
+        # to 1, matching the '| ' / ' |' convention used elsewhere.
+        [ValidateRange(0, [int]::MaxValue)]
+        [Parameter()]
+        [int]
+        $PadSpaces = 1
     )
 
     Begin {
@@ -49,6 +66,11 @@ function Format-Markdown{
             $Output += "$($Json | ConvertTo-Json -Depth 10 -Compress)`n"
             $Output += "```````n"
         } else {
+            $Pad = ' ' * $PadSpaces
+            $Separator = "$Pad|$Pad"
+            $Left = if ($NoOuterPipes) { '' } else { "|$Pad" }
+            $Right = if ($NoOuterPipes) { '' } else { "$Pad|" }
+
             foreach ($Key in $($Columns.Keys)) {
                 $Columns[$Key] = [Math]::Max($Columns[$Key], $Key.Length)
             }
@@ -57,20 +79,20 @@ function Format-Markdown{
             foreach ($Key in $Columns.Keys) {
                 $HeaderRow += ('{0,-' + $Columns[$Key] + '}') -f $Key
             }
-            $Output += "|$($HeaderRow -join ' | ')|`n"
+            $Output += "$Left$($HeaderRow -join $Separator)$Right`n"
 
             $SeparatorRow = @()
             foreach ($Key in $Columns.Keys) {
                 $SeparatorRow += '-' * $Columns[$Key]
             }
-            $Output += "|$($SeparatorRow -join ' | ')|`n"
+            $Output += "$Left$($SeparatorRow -join $Separator)$Right`n"
 
             foreach ($Item in $Items) {
                 $DataRow = @()
                 foreach($key in $Columns.Keys) {
                     $DataRow += ('{0,-' + $Columns[$key] + '}') -f $Item.($key)
                 }
-                $Output += "|$($DataRow -join ' | ')|`n"
+                $Output += "$Left$($DataRow -join $Separator)$Right`n"
             }
         }
         Write-Output $Output

--- a/tests/Format-Markdown.Tests.ps1
+++ b/tests/Format-Markdown.Tests.ps1
@@ -1,0 +1,139 @@
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '../src/Format-Markdown/Format-Markdown.psd1'
+    Import-Module $ModulePath -Force
+}
+
+Describe 'Format-Markdown' {
+
+    BeforeAll {
+        $TestObjects = @(
+            [PSCustomObject]@{ Name = 'a'; Value = 1 }
+            [PSCustomObject]@{ Name = 'bb'; Value = 22 }
+        )
+    }
+
+    Context 'Markdown table (default)' {
+
+        BeforeAll {
+            $Lines = ($TestObjects | Format-Markdown) -split "`n" | Where-Object { $_ -ne '' }
+        }
+
+        It 'wraps the header row in leading and trailing pipes, padded like the inner separators' {
+            $Lines[0] | Should -Be '| Name | Value |'
+        }
+
+        It 'wraps the separator row in leading and trailing pipes, padded like the inner separators' {
+            $Lines[1] | Should -Be '| ---- | ----- |'
+        }
+
+        It 'wraps each data row in leading and trailing pipes, padded like the inner separators' {
+            $Lines[2] | Should -Be '| a    | 1     |'
+            $Lines[3] | Should -Be '| bb   | 22    |'
+        }
+
+        It 'pads columns to the widest of the header and its values' {
+            $Lines | ForEach-Object { $_.Length | Should -Be $Lines[0].Length }
+        }
+    }
+
+    Context 'Markdown table with -NoOuterPipes' {
+
+        BeforeAll {
+            $Lines = ($TestObjects | Format-Markdown -NoOuterPipes) -split "`n" | Where-Object { $_ -ne '' }
+        }
+
+        It 'omits the leading and trailing pipe on the header row' {
+            $Lines[0] | Should -Be 'Name | Value'
+        }
+
+        It 'omits the leading and trailing pipe on the separator row' {
+            $Lines[1] | Should -Be '---- | -----'
+        }
+
+        It 'omits the leading and trailing pipe on each data row' {
+            $Lines[2] | Should -Be 'a    | 1    '
+            $Lines[3] | Should -Be 'bb   | 22   '
+        }
+
+        It 'still separates columns with an inner pipe' {
+            $Lines[0] | Should -Match '\|'
+        }
+    }
+
+    Context 'AsJsonTable' {
+
+        BeforeAll {
+            $Output = $TestObjects | Format-Markdown -AsJsonTable
+            $FenceLines = $Output -split "`n" | Where-Object { $_ -ne '' }
+        }
+
+        It 'wraps the payload in a json:table fenced code block' {
+            $FenceLines[0] | Should -Be '```json:table'
+            $FenceLines[-1] | Should -Be '```'
+        }
+
+        It 'emits fields, items, and filter in the JSON payload' {
+            $Json = $FenceLines[1] | ConvertFrom-Json
+            $Json.fields.key | Should -Be @('Name', 'Value')
+            $Json.items.Count | Should -Be 2
+            $Json.items[0].Name | Should -Be 'a'
+            $Json.items[1].Value | Should -Be 22
+            $Json.filter | Should -Be 'true'
+        }
+    }
+
+    Context 'Column discovery' {
+
+        It 'unions columns across objects with differing properties, in first-seen order' {
+            $Objects = @(
+                [PSCustomObject]@{ First = 1 }
+                [PSCustomObject]@{ First = 2; Second = 'x' }
+            )
+            $Lines = ($Objects | Format-Markdown) -split "`n" | Where-Object { $_ -ne '' }
+            $Lines[0] | Should -Be '| First | Second |'
+        }
+
+        It 'skips null property values when computing column width' {
+            $Objects = @(
+                [PSCustomObject]@{ Name = $null }
+                [PSCustomObject]@{ Name = 'longvalue' }
+            )
+            $Lines = ($Objects | Format-Markdown) -split "`n" | Where-Object { $_ -ne '' }
+            $Lines[1] | Should -Be '| --------- |'
+        }
+    }
+
+    Context 'PadSpaces' {
+
+        It 'defaults to a single space around every pipe' {
+            $Lines = ($TestObjects | Format-Markdown) -split "`n" | Where-Object { $_ -ne '' }
+            $Lines[0] | Should -Be '| Name | Value |'
+        }
+
+        It 'removes all padding around pipes when set to 0' {
+            $Lines = ($TestObjects | Format-Markdown -PadSpaces 0) -split "`n" | Where-Object { $_ -ne '' }
+            $Lines[0] | Should -Be '|Name|Value|'
+        }
+
+        It 'widens the padding around pipes when set above 1' {
+            $Lines = ($TestObjects | Format-Markdown -PadSpaces 2) -split "`n" | Where-Object { $_ -ne '' }
+            $Lines[0] | Should -Be '|  Name  |  Value  |'
+        }
+
+        It 'still applies to the inner separator when -NoOuterPipes is set' {
+            $Lines = ($TestObjects | Format-Markdown -NoOuterPipes -PadSpaces 2) -split "`n" | Where-Object { $_ -ne '' }
+            $Lines[0] | Should -Be 'Name  |  Value'
+        }
+
+        It 'rejects a negative value' {
+            { $TestObjects | Format-Markdown -PadSpaces -1 } | Should -Throw
+        }
+    }
+
+    Context 'fmd alias' {
+
+        It 'is registered as an alias for Format-Markdown' {
+            (Get-Alias fmd).Definition | Should -Be 'Format-Markdown'
+        }
+    }
+}


### PR DESCRIPTION
## Context

Makes the table's outer pipe optional and its padding configurable, and adds tests.

`Format-Markdown` turns PSObjects into markdown tables. #4 made the leading/trailing pipe on every row unconditional, but with no space after the opening pipe or before the closing one — inconsistent with the ` | ` used between columns everywhere else. This carries that commit forward, matches the padding to the [GFM spec's recommended](https://github.github.com/gfm/#tables-extension-) style, and makes both dimensions configurable: `-NoOuterPipes` drops the outer pipe, `-PadSpaces` changes the padding width. Supersedes #4, which this closes.

## Review guide

- **New options** — [`-NoOuterPipes` / `-PadSpaces` declared](https://github.com/chris-peterson/pwsh-fmd/pull/5/changes#diff-977e3b1646c656c9f5d53ccc83ba708141e574afb4975873cf069dc18646bf66R21) alongside `-AsJsonTable`; [row-building](https://github.com/chris-peterson/pwsh-fmd/pull/5/changes#diff-977e3b1646c656c9f5d53ccc83ba708141e574afb4975873cf069dc18646bf66R69) replaces the hardcoded `' | '` join with a computed separator/left/right.
- **Tests** — [Pester suite](https://github.com/chris-peterson/pwsh-fmd/pull/5/changes#diff-dffcbd4b54c7352e38ccac5b54b4a156569df4c83bd4715d0c2d53253e08736cR106) covers both pipe styles, `-PadSpaces`, JSON tables, and column discovery.
- **CI** — [new PR check](https://github.com/chris-peterson/pwsh-fmd/pull/5/changes#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R14) runs the suite; [deploy.yml](https://github.com/chris-peterson/pwsh-fmd/pull/5/changes#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R30) gates the Gallery publish on it passing.
- **Docs** — [README](https://github.com/chris-peterson/pwsh-fmd/pull/5/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46) / [docsify](https://github.com/chris-peterson/pwsh-fmd/pull/5/changes#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R46) examples were stale since #4 (never showed the outer pipe); fixed against verified command output.
